### PR TITLE
fix webpack dev server config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,7 +147,8 @@ module.exports = (env = {}) => {
       port: 8080,
       historyApiFallback: {
         rewrites: [
-          { from: /^\/scrivito/, to: '/scrivito/index.html' },
+          { from: /^\/scrivito$/, to: '/scrivito/index.html' },
+          { from: /^\/scrivito\//, to: '/scrivito/index.html' },
           { from: /./, to: '/index.html' },
         ],
       },


### PR DESCRIPTION
avoid redirecting to UI if the Url is:`/scrivito-at-the-beginning-of-url`

Otherwise, you'll see this:

<img width="880" alt="screen shot 2018-02-27 at 11 28 02 am" src="https://user-images.githubusercontent.com/39571/36723705-55227174-1bb1-11e8-9050-4e1d40ccbbe3.png">
